### PR TITLE
[UPDATE] support row_factory while query data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+tests/static/db.sqlite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "research-utils"
-version = "2021.09.22.1"
+version = "2021.09.22.2"
 description = "some utils for my research"
 authors = ["Rainforest Cheng <r08521610@ntu.edu.tw>"]
 

--- a/research_utils/sqlite/functional.py
+++ b/research_utils/sqlite/functional.py
@@ -1,11 +1,11 @@
-from .typing.sql import FieldOption
-from .typing.operator import ConditionSQLArgument, OperatorSQLArgument
-from typing import Dict, List, Tuple, Union
+from typing import Any, Callable, Dict, List, Tuple, Union
 import logging
+from ..decorators.logging import logger
 from pathlib import Path
 import sqlite3
-from sqlite3 import Error, Connection
-from ..decorators.logging import logger
+from sqlite3 import Error, Connection, Cursor
+from .typing.sql import FieldOption
+from .typing.operator import ConditionSQLArgument, OperatorSQLArgument
 
 
 def create_db_if_not_exist(database) -> None:
@@ -87,6 +87,7 @@ def insert(conn: Connection, table_name: str, fields: Union[List[str], Tuple[str
 def query(conn: Connection,
           table_name: str,
           fields: Union[List[str], Tuple[str]] = None,
+          row_factory: Callable[[Cursor, Tuple], Any] = None,
           where: Union[OperatorSQLArgument, ConditionSQLArgument] = None) -> List:
   """Query All Rows from Custom Table
 
@@ -104,6 +105,10 @@ def query(conn: Connection,
   {f'WHERE {where.sql}' if where is not None else ''}
   """
   logging.info(sql)
+
+  if row_factory is not None:
+    conn.row_factory = row_factory
+
   try:
     cur = conn.cursor()
     cur.execute(sql)

--- a/research_utils/sqlite/row_factory.py
+++ b/research_utils/sqlite/row_factory.py
@@ -1,0 +1,5 @@
+def dict_factory(cursor, row):
+  d = {}
+  for idx, col in enumerate(cursor.description):
+    d[col[0]] = row[idx]
+  return d

--- a/tests/test_sqlite_functional.py
+++ b/tests/test_sqlite_functional.py
@@ -6,6 +6,7 @@ from research_utils.decorators.logging import Logging_Level, config_logger
 from research_utils.sqlite.typing.sql import FieldType, NotNull, PrimaryKey
 from research_utils.sqlite.typing.operator import Lower
 from research_utils.sqlite.functional import create_connection, create_table, insert, query
+from research_utils.sqlite.row_factory import dict_factory
 
 table_name = 'test'
 fields = {
@@ -77,6 +78,7 @@ def test_query_where():
   rows = query(conn,
                table_name=table_name,
                fields=[key for key in fields.keys()],
+               row_factory=dict_factory,
                where=Lower('value', 0.5))
 
   assert rows is not None


### PR DESCRIPTION
```python
def query(conn: Connection,
          table_name: str,
          fields: Union[List[str], Tuple[str]] = None,
          row_factory: Callable[[Cursor, Tuple], Any] = None,
          where: Union[OperatorSQLArgument, ConditionSQLArgument] = None) -> List:
    ...
    if row_factory is not None:
        conn.row_factory = row_factory
```
```python
def dict_factory(cursor, row):
  d = {}
  for idx, col in enumerate(cursor.description):
    d[col[0]] = row[idx]
  return d
```